### PR TITLE
Update to address historical value lookups

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ repositories {
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.+'
     compile 'org.apache.commons:commons-math3:3.5'
+    compile 'org.apache.commons:commons-collections4:4.1'
     compile 'org.apache.commons:commons-io:1.3.2'
     compile 'com.google.code.gson:gson:2.5'
     compile 'com.tdunning:t-digest:3.1'

--- a/src/main/java/md2k/mCerebrum/cStress/features/StressEpisodeClassification.java
+++ b/src/main/java/md2k/mCerebrum/cStress/features/StressEpisodeClassification.java
@@ -45,18 +45,35 @@ public class StressEpisodeClassification {
     public static final double thresholdNo = 0.29;
 
     public static final int stressProbabilitySmoothingWindow = 3; // 3 minute
+    public static final int BUFFER_SIZE = 100;
+    public static final int BUFFER_SIZE_SMALL = 10;
 
     public StressEpisodeClassification(DataStreams datastreams, long windowSize) {
 
         DataPointStream dsStressProbability = datastreams.getDataPointStream(StreamConstants.ORG_MD2K_CSTRESS_PROBABILITY);
+
         DataPointStream dsStressProbabilityImputed = datastreams.getDataPointStream(StreamConstants.ORG_MD2K_CSTRESS_PROBABILITY_IMPUTED);
+        dsStressProbabilityImputed.setHistoricalBufferSize(BUFFER_SIZE_SMALL);
+
         DataPointStream dsStressProbabilitySmoothed = datastreams.getDataPointStream(StreamConstants.ORG_MD2K_CSTRESS_PROBABILITY_SMOOTHED);
+        dsStressProbabilitySmoothed.setHistoricalBufferSize(BUFFER_SIZE);
+
         DataPointStream dsStressProbabilityAvailable = datastreams.getDataPointStream(StreamConstants.ORG_MD2K_CSTRESS_PROBABILITY_AVAILABLE);
+        dsStressProbabilityAvailable.setHistoricalBufferSize(BUFFER_SIZE);
+
         DataPointStream dsEmaFast = datastreams.getDataPointStream(StreamConstants.ORG_MD2K_CSTRESS_STRESS_EPISODE_EMA_FAST);
+        dsEmaFast.setHistoricalBufferSize(BUFFER_SIZE_SMALL);
+
         DataPointStream dsEmaSlow = datastreams.getDataPointStream(StreamConstants.ORG_MD2K_CSTRESS_STRESS_EPISODE_EMA_SLOW);
+        dsEmaSlow.setHistoricalBufferSize(BUFFER_SIZE_SMALL);
+
         DataPointStream dsEmaSignal = datastreams.getDataPointStream(StreamConstants.ORG_MD2K_CSTRESS_STRESS_EPISODE_EMA_SIGNAL);
-        //DataPointStream dsHistogram = datastreams.getDataPointStream(StreamConstants.ORG_MD2K_CSTRESS_STRESS_EPISODE_HISTOGRAM);
+        dsEmaSignal.setHistoricalBufferSize(BUFFER_SIZE_SMALL);
+
         DataPointStream dsStressEpisodeClassification = datastreams.getDataPointStream(StreamConstants.ORG_MD2K_CSTRESS_STRESS_EPISODE_CLASSIFICATION);
+        dsStressEpisodeClassification.setHistoricalBufferSize(BUFFER_SIZE_SMALL);
+
+
 
         if (dsStressProbability.data.size() > 0) {
             DataPoint stressProbability = new DataPoint(dsStressProbability.getLatestTimestamp(), dsStressProbability.getLatestValue());
@@ -65,7 +82,7 @@ public class StressEpisodeClassification {
             dsStressProbabilityAvailable.add(new DataPoint(dsStressProbability.getLatestTimestamp(), 1.0));
         } else {
             //Handle missing datapoint. Imputation by carry forwarding the last known value.
-            long currentTimestamp = -1; //getCurrentTimestamp();
+            long currentTimestamp = -1;
             List<DataPoint> imputedHistoryLast = dsStressProbabilityImputed.getHistoricalNValues(1);
             if (imputedHistoryLast.size() > 0) {
                 if (imputedHistoryLast.get(0).timestamp == -1) {
@@ -85,7 +102,7 @@ public class StressEpisodeClassification {
 
             dsStressProbabilityAvailable.add(new DataPoint(currentTimestamp, 0.0));
         }
-        //Smoothing.smooth(dsStressProbabilitySmoothed, dsStressProbabilityImputed, stressProbabilitySmoothingWindow);
+
         smoothViaHistoricalValues(dsStressProbabilitySmoothed, dsStressProbabilityImputed, stressProbabilitySmoothingWindow);
 
         DataPoint stressProbability = new DataPoint(dsStressProbabilitySmoothed.getLatestTimestamp(), dsStressProbabilitySmoothed.getLatestValue());


### PR DESCRIPTION
Manual bounding of the history parameter for specific data streams vai a fixed size circular buffer.  An explicit call to set the historical size is currently needed to support this operation.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/md2korg/stream-processor/53)

<!-- Reviewable:end -->
